### PR TITLE
Add request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ip": "^=1.1.5",
     "mqtt": "^3.0.0",
     "node-fetch": "^2.3.0",
+    "request": "^2.88.2",
     "request-promise": "^4.2.5",
     "underscore": "^1.9.2"
   },


### PR DESCRIPTION
Plugin does not load due to the request library no longer being provided by request-promise. This PR adds the request library as a dependency.